### PR TITLE
Update DTR commands

### DIFF
--- a/rplidar.py
+++ b/rplidar.py
@@ -127,7 +127,7 @@ class RPLidar(object):
             self._serial_port = serial.Serial(
                 self.port, self.baudrate,
                 parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE,
-                timeout=self.timeout)
+                timeout=self.timeout, dsrdtr=True)
         except serial.SerialException as err:
             raise RPLidarException('Failed to connect to the sensor '
                                    'due to: %s' % err)
@@ -147,7 +147,7 @@ class RPLidar(object):
         '''Starts sensor motor'''
         self.logger.info('Starting motor')
         # For A1
-        self._serial_port.setDTR(False)
+        self._serial_port.dtr = False
 
         # For A2
         self.set_pwm(DEFAULT_MOTOR_PWM)
@@ -160,7 +160,7 @@ class RPLidar(object):
         self.set_pwm(0)
         time.sleep(.001)
         # For A1
-        self._serial_port.setDTR(True)
+        self._serial_port.dtr = True
         self.motor_running = False
 
     def _send_payload_cmd(self, cmd, payload):


### PR DESCRIPTION
I am using Python 3 with the RPLIDAR A2. I don't know too much about Serial port communication, but often when I restarted the code or ran it multiple times, I would get an `Incorrect descriptor starting bytes` error:
```
/Users/yash/Desktop/SmartWheels/test.py in run()
     22 def run():
     23     lidar = RPLidar('/dev/tty.SLAB_USBtoUART')
---> 24     info = lidar.get_info()
     25     health = lidar.get_health()
     26 

/Users/yash/anaconda3/lib/python3.5/site-packages/rplidar.py in get_info(self)
    209         '''
    210         self._send_cmd(GET_INFO_BYTE)
--> 211         dsize, is_single, dtype = self._read_descriptor()
    212         if dsize != INFO_LEN:
    213             raise RPLidarException('Wrong get_info reply length')

/Users/yash/anaconda3/lib/python3.5/site-packages/rplidar.py in _read_descriptor(self)
    187             raise RPLidarException('Descriptor length mismatch')
    188         elif not descriptor.startswith(SYNC_BYTE + SYNC_BYTE2):
--> 189             raise RPLidarException('Incorrect descriptor starting bytes')
    190         is_single = _b2i(descriptor[-2]) == 0
    191         return _b2i(descriptor[2]), is_single, _b2i(descriptor[-1])

RPLidarException: Incorrect descriptor starting bytes
```
or a `Wrong body size` error:
```
/Users/yash/Desktop/SmartWheels/test.py in update_line(num, iterator, line)
     10 
     11 def update_line(num, iterator, line):
---> 12     scan = np.array(next(iterator)).T
     13 
     14     angle = np.deg2rad((scan[1] + 90) % 360)

/Users/yash/anaconda3/lib/python3.5/site-packages/rplidar.py in iter_scans(self, max_buf_meas, min_len)
    355         scan = []
    356         iterator = self.iter_measurments(max_buf_meas)
--> 357         for new_scan, quality, angle, distance in iterator:
    358             if new_scan:
    359                 if len(scan) > min_len:

/Users/yash/anaconda3/lib/python3.5/site-packages/rplidar.py in iter_measurments(self, max_buf_meas)
    321             raise RPLidarException('Wrong response data type')
    322         while True:
--> 323             raw = self._read_response(dsize)
    324             self.logger.debug('Recieved scan response: %s' % raw)
    325             if max_buf_meas:

/Users/yash/anaconda3/lib/python3.5/site-packages/rplidar.py in _read_response(self, dsize)
    197         self.logger.debug('Recieved data: %s', data)
    198         if len(data) != dsize:
--> 199             raise RPLidarException('Wrong body size')
    200         return data
    201 

RPLidarException: Wrong body size
```
After some investigation, I visited the pySerial documentation and found that the `setDTR` method is [deprecated](http://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.setDTR). I think we need to use the [dtr](http://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.dtr) method instead. Then I noticed that in the [init](http://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.__init__) function, the flag `dsrdtr` must be set to `True` to "Enable hardware (DSR/DTR) flow control." With these edits to the code, my RPLIDAR A2 is able to work consistently. However, I still must call `get_info()` and/or `get_health()` before calling `iter_scans()` for some reason - not sure if this is unintended or by design. Please review these edits and let me know what you think. Thank you!